### PR TITLE
Adding reference to CBRIAN's API specification

### DIFF
--- a/NeuroHub Access.ipynb
+++ b/NeuroHub Access.ipynb
@@ -4,7 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Accessing NeuroHub using the CBRAIN API"
+    "# Accessing NeuroHub using the CBRAIN API\n",
+    "This notebook is intented to showcase a few example usage of the CBRAIN API v5.1.3 that powers the NeuroHub platform. For an exhautive list of endpoints, see https://app.swaggerhub.com/apis/prioux/CBRAIN/5.1.3"
    ]
   },
   {


### PR DESCRIPTION
The specification is accessible via SwaggerHub. 
The schema itself is also kept @ https://github.com/aces/cbrain/tree/master/BrainPortal/public/swagger 